### PR TITLE
Update 'find' output to remove leading tabs and report absolute paths

### DIFF
--- a/stoker/cli.py
+++ b/stoker/cli.py
@@ -35,6 +35,9 @@ def main(args=None):
     find_parser.add_argument("-e","--exts",dest='extensions',
                              default=None)
     find_parser.add_argument("--nocompressed",action='store_true')
+    find_parser.add_argument("-f","--full_paths",action='store_true',
+                             help="report full paths to matching "
+                             "objects")
     
     # Process the command line
     args = parser.parse_args()
@@ -52,6 +55,7 @@ def main(args=None):
     if args.command == "find":
         commands.find(args.dir,
                       exts=args.extensions,
-                      nocompressed=args.nocompressed)
+                      nocompressed=args.nocompressed,
+                      full_paths=args.full_paths)
 
 

--- a/stoker/commands.py
+++ b/stoker/commands.py
@@ -4,6 +4,7 @@
 #     Copyright (C) University of Manchester 2018 Peter Briggs
 #
 
+import os
 import index
 
 def _print_list(l):
@@ -50,7 +51,7 @@ def check_accessibility(dirn):
                                   obj.groupname,
                                   name)
 
-def find(dirn,exts=None,nocompressed=False):
+def find(dirn,exts=None,nocompressed=False,full_paths=False):
     """
     """
     indx = index.FilesystemObjectIndex(dirn)
@@ -58,6 +59,11 @@ def find(dirn,exts=None,nocompressed=False):
     print "%d matching objects" % len(matches)
     for name in matches:
         obj = indx[name]
-        print "%s%s" % (name,
+        if full_paths:
+            path = os.path.join(dirn,name)
+        else:
+            path = name
+        path = os.path.abspath(path)
+        print "%s%s" % (path,
                         (" -> %s" % obj.raw_symlink_target)
                         if obj.islink else "")

--- a/stoker/commands.py
+++ b/stoker/commands.py
@@ -58,6 +58,6 @@ def find(dirn,exts=None,nocompressed=False):
     print "%d matching objects" % len(matches)
     for name in matches:
         obj = indx[name]
-        print "\t%s%s" % (name,
-                          (" -> %s" % obj.raw_symlink_target)
-                          if obj.islink else "")
+        print "%s%s" % (name,
+                        (" -> %s" % obj.raw_symlink_target)
+                        if obj.islink else "")


### PR DESCRIPTION
PR to update the `find` command:

* Remove leading tab characters for each matching object
* Provide new `-f`/`--full_path` option to report the absolute path of matching objects