### PR TITLE
Add filtering by user to the 'find' subcommand

### DIFF
--- a/stoker/cli.py
+++ b/stoker/cli.py
@@ -34,6 +34,8 @@ def main(args=None):
     find_parser.add_argument("dir",default=None)
     find_parser.add_argument("-e","--exts",dest='extensions',
                              default=None)
+    find_parser.add_argument("-u","--users",dest='users',
+                             default=None)
     find_parser.add_argument("--nocompressed",action='store_true')
     find_parser.add_argument("-f","--full_paths",action='store_true',
                              help="report full paths to matching "
@@ -55,6 +57,7 @@ def main(args=None):
     if args.command == "find":
         commands.find(args.dir,
                       exts=args.extensions,
+                      users=args.users,
                       nocompressed=args.nocompressed,
                       full_paths=args.full_paths)
 

--- a/stoker/cli.py
+++ b/stoker/cli.py
@@ -32,13 +32,26 @@ def main(args=None):
     # 'find' command
     find_parser = subparsers.add_parser("find",
                                         help="search for files")
-    find_parser.add_argument("dir",default=None)
+    find_parser.add_argument("dir",default=None,
+                             help="directory to search")
     find_parser.add_argument("-e","--exts",dest='extensions',
-                             default=None)
+                             default=None,
+                             help="list of file extensions "
+                             "separated by commas; only include "
+                             "objects which have one of the "
+                             "listed extensions")
     find_parser.add_argument("-u","--users",dest='users',
-                             default=None)
-    find_parser.add_argument("-m","--mine",action='store_true')
-    find_parser.add_argument("--nocompressed",action='store_true')
+                             default=None,
+                             help="list of one or more user names "
+                             "separated by commas; only include "
+                             "objects owned by one of the listed "
+                             "users")
+    find_parser.add_argument("-m","--mine",action='store_true',
+                             help="only include objects which are "
+                             "owned by the current user (overrides "
+                             "--users)")
+    find_parser.add_argument("--nocompressed",action='store_true',
+                             help="don't include compressed objects")
     find_parser.add_argument("-f","--full_paths",action='store_true',
                              help="report full paths to matching "
                              "objects")

--- a/stoker/cli.py
+++ b/stoker/cli.py
@@ -4,6 +4,7 @@
 #     Copyright (C) University of Manchester 2018 Peter Briggs
 #
 import argparse
+import getpass
 import commands
 import index
 
@@ -36,6 +37,7 @@ def main(args=None):
                              default=None)
     find_parser.add_argument("-u","--users",dest='users',
                              default=None)
+    find_parser.add_argument("-m","--mine",action='store_true')
     find_parser.add_argument("--nocompressed",action='store_true')
     find_parser.add_argument("-f","--full_paths",action='store_true',
                              help="report full paths to matching "
@@ -55,9 +57,13 @@ def main(args=None):
 
     # Find
     if args.command == "find":
+        if args.mine:
+            users = getpass.getuser()
+        else:
+            users = args.users
         commands.find(args.dir,
                       exts=args.extensions,
-                      users=args.users,
+                      users=users,
                       nocompressed=args.nocompressed,
                       full_paths=args.full_paths)
 

--- a/stoker/commands.py
+++ b/stoker/commands.py
@@ -51,11 +51,13 @@ def check_accessibility(dirn):
                                   obj.groupname,
                                   name)
 
-def find(dirn,exts=None,nocompressed=False,full_paths=False):
+def find(dirn,exts=None,users=None,nocompressed=False,
+         full_paths=False):
     """
     """
     indx = index.FilesystemObjectIndex(dirn)
-    matches = index.find(indx,exts=exts,nocompressed=nocompressed)
+    matches = index.find(indx,exts=exts,users=users,
+                         nocompressed=nocompressed)
     print "%d matching objects" % len(matches)
     for name in matches:
         obj = indx[name]

--- a/stoker/index.py
+++ b/stoker/index.py
@@ -278,21 +278,28 @@ def check_accessibility(indx):
             inaccessible.append(name)
     return inaccessible
 
-def find(indx,exts=None,nocompressed=False):
+def find(indx,exts=None,users=None,nocompressed=False):
     """
     Find matching objects in an ObjectIndex
     """
-    matches = []
+    matches = list()
+    if exts is None and users is None:
+        return matches
     if exts is not None:
         exts = [x.strip('.') for x in exts.split(',')]
+        for name in indx.names:
+            obj = indx[name]
+            for ext in exts:
+                if ext in obj.extension.split('.'):
+                    matches.append(name)
+                    break
     else:
-        exts = list()
-    for name in indx.names:
-        obj = indx[name]
-        if nocompressed and obj.iscompressed:
-            continue
-        for ext in exts:
-            if ext in obj.extension.split('.'):
-                matches.append(name)
-                break
+        matches = indx.names
+    if users is not None:
+        users = [x for x in users.split(',')]
+        matches = filter(lambda x: indx[x].username in users,
+                         matches)
+    if nocompressed:
+        matches = filter(lambda x: not indx[x].iscompressed,
+                         matches)
     return sorted(matches)

--- a/stoker/test/test_index.py
+++ b/stoker/test/test_index.py
@@ -687,3 +687,33 @@ class TestFindFunction(unittest.TestCase):
                           "analysis/fastqs/PJB_R2.fastq",
                           "analysis/trimming/PJB_R1.trimmed.fastq",
                           "analysis/trimming/PJB_R2.trimmed.fastq"])
+
+    def test_find_owned_by_users(self):
+        # Make reference directory
+        os.mkdir("test")
+        self._populate_dir("test")
+        # Build index
+        indx = FilesystemObjectIndex("test")
+        # Find files owned by current user
+        current_username = getpass.getuser()
+        self.assertEqual(find(indx,exts="fastq",
+                              users=current_username),
+                         ["analysis/fastqs/PJB_R1.fastq",
+                          "analysis/fastqs/PJB_R2.fastq",
+                          "analysis/trimming/PJB_R1.trimmed.fastq",
+                          "analysis/trimming/PJB_R2.trimmed.fastq",
+                          "fastqs/PJB_S1_R1_001.fastq.gz",
+                          "fastqs/PJB_S1_R2_001.fastq.gz"])
+        # Find files owned by different user
+        self.assertEqual(find(indx,exts="fastq",
+                              users="non_existent_user0123"),[])
+        # Find files owned by multiple users
+        self.assertEqual(find(indx,exts="fastq",
+                              users=",".join((current_username,
+                                              "non_existent_user0123"))),
+                         ["analysis/fastqs/PJB_R1.fastq",
+                          "analysis/fastqs/PJB_R2.fastq",
+                          "analysis/trimming/PJB_R1.trimmed.fastq",
+                          "analysis/trimming/PJB_R2.trimmed.fastq",
+                          "fastqs/PJB_S1_R1_001.fastq.gz",
+                          "fastqs/PJB_S1_R2_001.fastq.gz"])


### PR DESCRIPTION
PR which adds new options for filtering by user to the `find` subcommand:

* `-u`/`--users`: specify one or more users, or
* `-m`/`--mine`: equivalent to `-u <CURRENT_USER>`