### PR TITLE
'find': only match the last component of the file extension

### DIFF
--- a/stoker/index.py
+++ b/stoker/index.py
@@ -145,6 +145,16 @@ class FilesystemObject(object):
         return '.'.join(os.path.basename(self.path).split('.')[1:])
 
     @property
+    def type_extension(self):
+        if self.iscompressed:
+            try:
+                return self.extension.split('.')[-2]
+            except IndexError:
+                return ""
+        else:
+            return self.extension.split('.')[-1]
+
+    @property
     def iscompressed(self):
         return (self.path.split('.')[-1] in ('gz','bz2'))
 
@@ -290,7 +300,7 @@ def find(indx,exts=None,users=None,nocompressed=False):
         for name in indx.names:
             obj = indx[name]
             for ext in exts:
-                if ext in obj.extension.split('.'):
+                if ext == obj.type_extension:
                     matches.append(name)
                     break
     else:

--- a/stoker/test/test_index.py
+++ b/stoker/test/test_index.py
@@ -276,6 +276,8 @@ class TestFilesystemObject(unittest.TestCase):
             fp.write("test")
         with open("test.txt.filtered.gz.1","w") as fp:
             fp.write("test")
+        with open("test.gz","w") as fp:
+            fp.write("test")
         with open("test","w") as fp:
             fp.write("test")
         # Check extensions
@@ -285,7 +287,30 @@ class TestFilesystemObject(unittest.TestCase):
                          "txt.gz")
         self.assertEqual(FilesystemObject("test.txt.filtered.gz.1").extension,
                          "txt.filtered.gz.1")
+        self.assertEqual(FilesystemObject("test.gz").extension,"gz")
         self.assertEqual(FilesystemObject("test").extension,"")
+
+    def test_type_extension(self):
+        # Make test filesystem objects
+        with open("test.txt","w") as fp:
+            fp.write("test")
+        with open("test.txt.gz","w") as fp:
+            fp.write("test")
+        with open("test.txt.filtered.gz.1","w") as fp:
+            fp.write("test")
+        with open("test.gz","w") as fp:
+            fp.write("test")
+        with open("test","w") as fp:
+            fp.write("test")
+        # Check type extensions
+        self.assertEqual(FilesystemObject("test.txt").type_extension,
+                         "txt")
+        self.assertEqual(FilesystemObject("test.txt.gz").type_extension,
+                         "txt")
+        self.assertEqual(FilesystemObject("test.txt.filtered.gz.1").type_extension,
+                         "1")
+        self.assertEqual(FilesystemObject("test.gz").type_extension,"")
+        self.assertEqual(FilesystemObject("test").type_extension,"")
 
 class TestFilesystemObjectIndex(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Adds a new FileSystemObject property 'type_extension', and uses this to filter on file extensions in the 'find' command.