### PR TITLE
'find' command: add --size option

### DIFF
--- a/stoker/cli.py
+++ b/stoker/cli.py
@@ -40,6 +40,13 @@ def main(args=None):
                              "separated by commas; only include "
                              "objects which have one of the "
                              "listed extensions")
+    find_parser.add_argument("-s","--size",metavar='MINSIZE',
+                             dest='min_size',default=None,
+                             help="only include objects greater "
+                             "than or equal to MINSIZE; MINSIZE "
+                             "must be either: a number of bytes, "
+                             "or an integer followed by 'K' (1024 "
+                             "bytes), 'M' (1024K), or 'G' (1024M)")
     find_parser.add_argument("-u","--users",dest='users',
                              default=None,
                              help="list of one or more user names "
@@ -76,9 +83,25 @@ def main(args=None):
             users = getpass.getuser()
         else:
             users = args.users
+        if args.min_size:
+            min_size = args.min_size
+            try:
+                min_size = int(min_size)
+            except ValueError:
+                min_size,units = (int(min_size[:-1]),min_size[-1])
+                if units == 'G':
+                    min_size = min_size*1024*1024*1024
+                elif units == 'M':
+                    min_size = min_size*1024*1024
+                elif units == 'K':
+                    min_size = min_size*1024
+                else:
+                    raise Exception("%s: invalid size option" %
+                                    args.min_size)
         commands.find(args.dir,
                       exts=args.extensions,
                       users=users,
+                      size=min_size,
                       nocompressed=args.nocompressed,
                       full_paths=args.full_paths)
 

--- a/stoker/commands.py
+++ b/stoker/commands.py
@@ -51,13 +51,13 @@ def check_accessibility(dirn):
                                   obj.groupname,
                                   name)
 
-def find(dirn,exts=None,users=None,nocompressed=False,
+def find(dirn,exts=None,users=None,size=None,nocompressed=False,
          full_paths=False):
     """
     """
     indx = index.FilesystemObjectIndex(dirn)
     matches = index.find(indx,exts=exts,users=users,
-                         nocompressed=nocompressed)
+                         size=size,nocompressed=nocompressed)
     print "%d matching objects" % len(matches)
     for name in matches:
         obj = indx[name]

--- a/stoker/index.py
+++ b/stoker/index.py
@@ -289,12 +289,12 @@ def check_accessibility(indx):
             inaccessible.append(name)
     return inaccessible
 
-def find(indx,exts=None,users=None,nocompressed=False):
+def find(indx,exts=None,users=None,size=None,nocompressed=False):
     """
     Find matching objects in an ObjectIndex
     """
     matches = list()
-    if exts is None and users is None:
+    if exts is None and users is None and size is None:
         return matches
     if exts is not None:
         exts = [x.strip('.') for x in exts.split(',')]
@@ -309,6 +309,9 @@ def find(indx,exts=None,users=None,nocompressed=False):
     if users is not None:
         users = [x for x in users.split(',')]
         matches = filter(lambda x: indx[x].username in users,
+                         matches)
+    if size is not None:
+        matches = filter(lambda x: indx[x].isfile and indx[x].size >= size,
                          matches)
     if nocompressed:
         matches = filter(lambda x: not indx[x].iscompressed,


### PR DESCRIPTION
PR adds a new `--size` option to the `find` command, which filters search results on minimum file size.