### PR TITLE
find command: add long listing format

### DIFF
--- a/stoker/cli.py
+++ b/stoker/cli.py
@@ -83,8 +83,8 @@ def main(args=None):
             users = getpass.getuser()
         else:
             users = args.users
-        if args.min_size:
-            min_size = args.min_size
+        min_size = args.min_size
+        if min_size:
             try:
                 min_size = int(min_size)
             except ValueError:

--- a/stoker/cli.py
+++ b/stoker/cli.py
@@ -61,6 +61,11 @@ def main(args=None):
                              help="don't include compressed objects "
                              "(i.e. those with %s extensions)" %
                              ', '.join(index.COMPRESSED_FILE_EXTENSIONS))
+    find_parser.add_argument("-l",action='store_true',
+                             dest="long_listing",
+                             help="use a long listing format when "
+                             "reporting results (includes user and "
+                             "size)")
     find_parser.add_argument("-f","--full_paths",action='store_true',
                              help="report full paths to matching "
                              "objects")
@@ -103,6 +108,7 @@ def main(args=None):
                       users=users,
                       size=min_size,
                       nocompressed=args.nocompressed,
+                      long_listing=args.long_listing,
                       full_paths=args.full_paths)
 
 

--- a/stoker/commands.py
+++ b/stoker/commands.py
@@ -13,6 +13,16 @@ def _print_list(l):
     for i in l:
         print "\t%s" % i
 
+def _pretty_print_size(s):
+    """
+    """
+    units = "bKMG"
+    i = 0
+    while s > 1024 and units[i] != 'G':
+        s = float(s)/1024.0
+        i += 1
+    return "%.1f%s" % (s,units[i])
+
 def compare(source,target):
     """
     """
@@ -70,6 +80,6 @@ def find(dirn,exts=None,users=None,size=None,nocompressed=False,
                         if obj.islink else "")
         if long_listing:
             output = "%s %s %s" % (obj.username,
-                                   obj.size,
+                                   _pretty_print_size(obj.size),
                                    output)
         print output

--- a/stoker/commands.py
+++ b/stoker/commands.py
@@ -79,7 +79,7 @@ def find(dirn,exts=None,users=None,size=None,nocompressed=False,
                         (" -> %s" % obj.raw_symlink_target)
                         if obj.islink else "")
         if long_listing:
-            output = "%s %s %s" % (obj.username,
-                                   _pretty_print_size(obj.size),
-                                   output)
+            output = "%s\t%s\t%s" % (obj.username,
+                                     _pretty_print_size(obj.size),
+                                     output)
         print output

--- a/stoker/commands.py
+++ b/stoker/commands.py
@@ -52,7 +52,7 @@ def check_accessibility(dirn):
                                   name)
 
 def find(dirn,exts=None,users=None,size=None,nocompressed=False,
-         full_paths=False):
+         long_listing=False,full_paths=False):
     """
     """
     indx = index.FilesystemObjectIndex(dirn)
@@ -65,6 +65,11 @@ def find(dirn,exts=None,users=None,size=None,nocompressed=False,
             path = os.path.abspath(os.path.join(dirn,name))
         else:
             path = name
-        print "%s%s" % (path,
+        output = "%s%s" % (path,
                         (" -> %s" % obj.raw_symlink_target)
                         if obj.islink else "")
+        if long_listing:
+            output = "%s %s %s" % (obj.username,
+                                   obj.size,
+                                   output)
+        print output


### PR DESCRIPTION
PR adds a `-l` option to the `find` command, to also output the associated username and size for each matching object.