### PR TITLE
'find' command: add --only_hidden option

### DIFF
--- a/stoker/cli.py
+++ b/stoker/cli.py
@@ -47,6 +47,9 @@ def main(args=None):
                              "must be either: a number of bytes, "
                              "or an integer followed by 'K' (1024 "
                              "bytes), 'M' (1024K), or 'G' (1024M)")
+    find_parser.add_argument("--only_hidden",action='store_true',
+                             dest='only_hidden',
+                             help="only report 'hidden' objects")
     find_parser.add_argument("-u","--users",dest='users',
                              default=None,
                              help="list of one or more user names "
@@ -107,6 +110,7 @@ def main(args=None):
                       exts=args.extensions,
                       users=users,
                       size=min_size,
+                      only_hidden=args.only_hidden,
                       nocompressed=args.nocompressed,
                       long_listing=args.long_listing,
                       full_paths=args.full_paths)

--- a/stoker/commands.py
+++ b/stoker/commands.py
@@ -62,12 +62,13 @@ def check_accessibility(dirn):
                                   name)
 
 def find(dirn,exts=None,users=None,size=None,nocompressed=False,
-         long_listing=False,full_paths=False):
+         only_hidden=False,long_listing=False,full_paths=False):
     """
     """
     indx = index.FilesystemObjectIndex(dirn)
     matches = index.find(indx,exts=exts,users=users,
-                         size=size,nocompressed=nocompressed)
+                         size=size,nocompressed=nocompressed,
+                         only_hidden=only_hidden)
     print "%d matching objects" % len(matches)
     for name in matches:
         obj = indx[name]

--- a/stoker/index.py
+++ b/stoker/index.py
@@ -110,6 +110,13 @@ class FilesystemObject(object):
         return os.readlink(self.path)
 
     @property
+    def ishidden(self):
+        for ele in self.path.split(os.sep):
+            if ele.startswith('.'):
+                return True
+        return False
+
+    @property
     def isaccessible(self):
         st_mode = self._st.st_mode
         if self.uid == os.getuid():
@@ -289,12 +296,16 @@ def check_accessibility(indx):
             inaccessible.append(name)
     return inaccessible
 
-def find(indx,exts=None,users=None,size=None,nocompressed=False):
+def find(indx,exts=None,users=None,size=None,only_hidden=False,
+         nocompressed=False):
     """
     Find matching objects in an ObjectIndex
     """
     matches = list()
-    if exts is None and users is None and size is None:
+    if exts is None and \
+       users is None and \
+       size is None and \
+       only_hidden is False:
         return matches
     if exts is not None:
         exts = [x.strip('.') for x in exts.split(',')]
@@ -312,6 +323,9 @@ def find(indx,exts=None,users=None,size=None,nocompressed=False):
                          matches)
     if size is not None:
         matches = filter(lambda x: indx[x].isfile and indx[x].size >= size,
+                         matches)
+    if only_hidden:
+        matches = filter(lambda x: indx[x].ishidden,
                          matches)
     if nocompressed:
         matches = filter(lambda x: not indx[x].iscompressed,

--- a/stoker/test/test_index.py
+++ b/stoker/test/test_index.py
@@ -222,6 +222,33 @@ class TestFilesystemObject(unittest.TestCase):
             FilesystemObject("missing.lnk").raw_symlink_target,
             "missing")
 
+    def test_ishidden(self):
+        # Make test filesystem objects
+        with open("test.txt","w") as fp:
+            fp.write("test")
+        self.assertFalse(FilesystemObject("test.txt").ishidden)
+        with open(".hidden.txt","w") as fp:
+            fp.write("test")
+        self.assertTrue(FilesystemObject(".hidden.txt").ishidden)
+        # Directory
+        os.mkdir("test.dir")
+        self.assertFalse(FilesystemObject("test.dir").ishidden)
+        os.mkdir(".hidden.dir")
+        self.assertTrue(FilesystemObject(".hidden.dir").ishidden)
+        # Files in subdirs
+        with open("test.dir/test.txt","w") as fp:
+            fp.write("test")
+        self.assertFalse(FilesystemObject("test.dir/test.txt").ishidden)
+        with open("test.dir/.hidden.txt","w") as fp:
+            fp.write("test")
+        self.assertTrue(FilesystemObject("test.dir/.hidden.txt").ishidden)
+        with open(".hidden.dir/test.txt","w") as fp:
+            fp.write("test")
+        self.assertTrue(FilesystemObject(".hidden.dir/test.txt").ishidden)
+        with open(".hidden.dir/.hidden.txt","w") as fp:
+            fp.write("test")
+        self.assertTrue(FilesystemObject(".hidden.dir/.hidden.txt").ishidden)
+
     def test_isaccessible(self):
         # Make test filesystem objects
         with open("test.txt","w") as fp:


### PR DESCRIPTION
PR adds an `--only_hidden` option to the `find` command, which only reports 'hidden' objects.