### PR TITLE
'find' command: add --nosymlinks option

### DIFF
--- a/stoker/cli.py
+++ b/stoker/cli.py
@@ -60,6 +60,9 @@ def main(args=None):
                              help="only include objects which are "
                              "owned by the current user (overrides "
                              "--users)")
+    find_parser.add_argument("--nosymlinks",action='store_true',
+                             help="don't include objects which are "
+                             "symlinks")
     find_parser.add_argument("--nocompressed",action='store_true',
                              help="don't include compressed objects "
                              "(i.e. those with %s extensions)" %
@@ -113,6 +116,7 @@ def main(args=None):
                       size=min_size,
                       only_hidden=args.only_hidden,
                       nocompressed=args.nocompressed,
+                      nosymlinks=args.nosymlinks,
                       long_listing=args.long_listing,
                       full_paths=args.full_paths)
 

--- a/stoker/commands.py
+++ b/stoker/commands.py
@@ -82,12 +82,14 @@ def check_accessibility(dirn):
                                   name)
 
 def find(dirn,exts=None,users=None,size=None,nocompressed=False,
-         only_hidden=False,long_listing=False,full_paths=False):
+         nosymlinks=False,only_hidden=False,long_listing=False,
+         full_paths=False):
     """
     """
     indx = index.FilesystemObjectIndex(dirn)
     matches = index.find(indx,exts=exts,users=users,
                          size=size,nocompressed=nocompressed,
+                         nosymlinks=nosymlinks,
                          only_hidden=only_hidden)
     print "%d matching objects" % len(matches)
     for name in matches:

--- a/stoker/index.py
+++ b/stoker/index.py
@@ -297,7 +297,7 @@ def check_accessibility(indx):
     return inaccessible
 
 def find(indx,exts=None,users=None,size=None,only_hidden=False,
-         nocompressed=False):
+         nosymlinks=False,nocompressed=False):
     """
     Find matching objects in an ObjectIndex
     """
@@ -326,6 +326,9 @@ def find(indx,exts=None,users=None,size=None,only_hidden=False,
                          matches)
     if only_hidden:
         matches = filter(lambda x: indx[x].ishidden,
+                         matches)
+    if nosymlinks:
+        matches = filter(lambda x: not indx[x].islink,
                          matches)
     if nocompressed:
         matches = filter(lambda x: not indx[x].iscompressed,


### PR DESCRIPTION
PR to add a `--nosymlinks` option to the `find` command, which excludes symbolic links from the results.