### PR TITLE
Migrate stoker to Python 3 & drop Python 2 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@
 language: python
 python:
   - "3.6"
+  - "3.7"
+  - "3.8"
 
 install:
   - "pip install ."

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 
 language: python
 python:
-  - "2.7"
+  - "3.6"
 
 install:
   - "pip install ."

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 Setup script to install 'stoker' package
 
-Copyright (C) University of Manchester 2018 Peter Briggs
+Copyright (C) University of Manchester 2018-2021 Peter Briggs
 
 """
 

--- a/stoker/cli.py
+++ b/stoker/cli.py
@@ -79,7 +79,7 @@ def main(args=None):
     
     # Process the command line
     args = parser.parse_args()
-    print "Command: %s" % args.command
+    print("Command: %s" % args.command)
 
     # Compare
     if args.command == "compare":

--- a/stoker/cli.py
+++ b/stoker/cli.py
@@ -5,8 +5,8 @@
 #
 import argparse
 import getpass
-import commands
-import index
+from . import commands
+from . import index
 
 def main(args=None):
     

--- a/stoker/cli.py
+++ b/stoker/cli.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #     cli.py: command line interfaces
-#     Copyright (C) University of Manchester 2018 Peter Briggs
+#     Copyright (C) University of Manchester 2018-2021 Peter Briggs
 #
 import argparse
 import getpass

--- a/stoker/commands.py
+++ b/stoker/commands.py
@@ -11,7 +11,7 @@ def _print_list(l):
     """
     """
     for i in l:
-        print "\t%s" % i
+        print("\t%s" % i)
 
 def _pretty_print_size(s):
     """
@@ -39,9 +39,9 @@ def _summarise_find(names,indx):
             user_sizes[obj.username] = size
         total_size += size
     for user in user_sizes:
-        print "# %s:\t%s" % (user,
-                             _pretty_print_size(user_sizes[user]))
-    print "# Total:\t%s" % _pretty_print_size(total_size)
+        print("# %s:\t%s" % (user,
+                             _pretty_print_size(user_sizes[user])))
+    print("# Total:\t%s" % _pretty_print_size(total_size))
 
 def compare(source,target):
     """
@@ -49,23 +49,23 @@ def compare(source,target):
     source = index.FilesystemObjectIndex(source)
     target = index.FilesystemObjectIndex(target)
     diff = index.compare(source,target)
-    print "%d missing objects" % len(diff.missing)
+    print("%d missing objects" % len(diff.missing))
     _print_list(diff.missing)
-    print "%d additional objects" % len(diff.extra)
+    print("%d additional objects" % len(diff.extra))
     _print_list(diff.extra)
-    print "%d objects changed type" % len(diff.changed_type)
+    print("%d objects changed type" % len(diff.changed_type))
     _print_list(diff.changed_type)
-    print "%d objects changed size" % len(diff.changed_size)
+    print("%d objects changed size" % len(diff.changed_size))
     _print_list(diff.changed_size)
-    print "%d objects changed MD5" % len(diff.changed_md5)
+    print("%d objects changed MD5" % len(diff.changed_md5))
     _print_list(diff.changed_md5)
-    print "%d objects changed time" % len(diff.changed_time)
+    print("%d objects changed time" % len(diff.changed_time))
     _print_list(diff.changed_time)
-    print "%d objects changed link" % len(diff.changed_link)
+    print("%d objects changed link" % len(diff.changed_link))
     _print_list(diff.changed_link)
-    print "%d restricted objects (source)" % len(diff.restricted_source)
+    print("%d restricted objects (source)" % len(diff.restricted_source))
     _print_list(diff.restricted_source)
-    print "%d restricted objects (target)" % len(diff.restricted_target)
+    print("%d restricted objects (target)" % len(diff.restricted_target))
     _print_list(diff.restricted_target)
 
 def check_accessibility(dirn):
@@ -73,13 +73,13 @@ def check_accessibility(dirn):
     """
     indx = index.FilesystemObjectIndex(dirn)
     inaccessible = index.check_accessibility(indx)
-    print "%d inaccessible objects" % len(inaccessible)
+    print("%d inaccessible objects" % len(inaccessible))
     for name in inaccessible:
         obj = indx[name]
-        print "\t%s %s:%s\t%s" % (obj.linux_permissions,
+        print("\t%s %s:%s\t%s" % (obj.linux_permissions,
                                   obj.username,
                                   obj.groupname,
-                                  name)
+                                  name))
 
 def find(dirn,exts=None,users=None,size=None,nocompressed=False,
          nosymlinks=False,only_hidden=False,long_listing=False,
@@ -91,7 +91,7 @@ def find(dirn,exts=None,users=None,size=None,nocompressed=False,
                          size=size,nocompressed=nocompressed,
                          nosymlinks=nosymlinks,
                          only_hidden=only_hidden)
-    print "%d matching objects" % len(matches)
+    print("%d matching objects" % len(matches))
     for name in matches:
         obj = indx[name]
         if full_paths:
@@ -105,6 +105,6 @@ def find(dirn,exts=None,users=None,size=None,nocompressed=False,
             output = "%s\t%s\t%s" % (obj.username,
                                      _pretty_print_size(obj.size),
                                      output)
-        print output
+        print(output)
     if long_listing:
         _summarise_find(matches,indx)

--- a/stoker/commands.py
+++ b/stoker/commands.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #     index.py: indexing classes and functions
-#     Copyright (C) University of Manchester 2018 Peter Briggs
+#     Copyright (C) University of Manchester 2018-2021 Peter Briggs
 #
 
 import os

--- a/stoker/commands.py
+++ b/stoker/commands.py
@@ -5,7 +5,7 @@
 #
 
 import os
-import index
+from . import index
 
 def _print_list(l):
     """

--- a/stoker/index.py
+++ b/stoker/index.py
@@ -128,9 +128,12 @@ class FilesystemObject(object):
     @property
     def md5sum(self):
         chksum = hashlib.md5()
-        with open(self.path,'rb') as f:
-            for block in iter(lambda: f.read(MD5_BLOCK_SIZE),''):
-                chksum.update(block)
+        with open(self.path,"rb",buffering=MD5_BLOCK_SIZE) as fp:
+            for block in iter(fp.read,''):
+                if block:
+                    chksum.update(block)
+                else:
+                    break
         return chksum.hexdigest()
 
     @property

--- a/stoker/index.py
+++ b/stoker/index.py
@@ -1,7 +1,7 @@
-#!/bin/env python
+#!/usr/bin/env python3
 #
 #     index.py: indexing classes and functions
-#     Copyright (C) University of Manchester 2018 Peter Briggs
+#     Copyright (C) University of Manchester 2018-2021 Peter Briggs
 #
 
 """

--- a/stoker/index.py
+++ b/stoker/index.py
@@ -198,13 +198,13 @@ class FilesystemObjectIndex(object):
         """
         Build index from filesystem
         """
-        print "Indexing objects in %s" % self._dirn
+        print("Indexing objects in %s" % self._dirn)
         for d in os.walk(self._dirn):
             for f in d[1]:
                 self._add_object(d[0],f)
             for f in d[2]:
                 self._add_object(d[0],f)
-        print "Added %d objects" % len(self)
+        print("Added %d objects" % len(self))
 
     def _add_object(self,*args):
         """

--- a/stoker/test/test_index.py
+++ b/stoker/test/test_index.py
@@ -22,10 +22,10 @@ from stoker.index import find
 def _remove_dir(dirn):
     for root,dirs,files in os.walk(dirn):
         for name in dirs:
-            os.chmod(os.path.join(root,name),0755)
+            os.chmod(os.path.join(root,name),0o755)
         for name in files:
             try:
-                os.chmod(os.path.join(root,name),0644)
+                os.chmod(os.path.join(root,name),0o644)
             except OSError:
                 pass
     shutil.rmtree(dirn)
@@ -264,10 +264,10 @@ class TestFilesystemObject(unittest.TestCase):
         os.symlink("missing","missing.lnk")
         self.assertTrue(FilesystemObject("missing.lnk").isaccessible)
         # Set permissions to make objects unreadable
-        os.chmod("test.txt",0044)
+        os.chmod("test.txt",0o044)
         self.assertFalse(FilesystemObject("test.txt").isaccessible)
         self.assertTrue(FilesystemObject("test.lnk").isaccessible)
-        os.chmod("test.dir",0055)
+        os.chmod("test.dir",0o055)
         self.assertFalse(FilesystemObject("test.dir").isaccessible)
 
     def test_md5sum(self):
@@ -282,16 +282,16 @@ class TestFilesystemObject(unittest.TestCase):
         with open("test.txt","w") as fp:
             fp.write("test")
         # Set permissions and test outputs
-        os.chmod("test.txt",0444)
+        os.chmod("test.txt",0o444)
         self.assertEqual(FilesystemObject("test.txt").linux_permissions,
                          "r--r--r--")
-        os.chmod("test.txt",0666)
+        os.chmod("test.txt",0o666)
         self.assertEqual(FilesystemObject("test.txt").linux_permissions,
                          "rw-rw-rw-")
-        os.chmod("test.txt",0750)
+        os.chmod("test.txt",0o750)
         self.assertEqual(FilesystemObject("test.txt").linux_permissions,
                          "rwxr-x---")
-        os.chmod("test.txt",0070)
+        os.chmod("test.txt",0o070)
         self.assertEqual(FilesystemObject("test.txt").linux_permissions,
                          "---rwx---")
 
@@ -585,9 +585,9 @@ class TestCompareFunction(unittest.TestCase):
         # Make directory to compare
         self._copy_dir("test1","test2")
         # Remove permissions on source subdir (restricted_source)
-        os.chmod("test1/test1.dir",0055)
+        os.chmod("test1/test1.dir",0o055)
         # Remove permissions on target subdir (restricted_target)
-        os.chmod("test2/test2.dir",0055)
+        os.chmod("test2/test2.dir",0o055)
         # Build indexes
         indx1 = FilesystemObjectIndex("test1")
         indx2 = FilesystemObjectIndex("test2")
@@ -651,9 +651,9 @@ class TestCheckAccessibilityFunction(unittest.TestCase):
         os.mkdir("test")
         self._populate_dir("test")
         # Remove permissions on subdir
-        os.chmod("test/test1.dir",0055)
+        os.chmod("test/test1.dir",0o055)
         # Remove permissions on file
-        os.chmod("test/test2.dir/test.txt",0044)
+        os.chmod("test/test2.dir/test.txt",0o044)
         # Build index
         indx = FilesystemObjectIndex("test")
         self.assertEqual(check_accessibility(indx),

--- a/stoker/test/test_index.py
+++ b/stoker/test/test_index.py
@@ -56,7 +56,7 @@ class TestFilesystemObject(unittest.TestCase):
         # Doesn't exist
         self.assertFalse(FilesystemObject("test").exists)
         # File that exists
-        with open("test.txt","w") as fp:
+        with open("test.txt","wt") as fp:
             fp.write("test")
         self.assertTrue(FilesystemObject("test.txt").exists)
         # Directory
@@ -73,7 +73,7 @@ class TestFilesystemObject(unittest.TestCase):
         # Get current time in seconds
         timestamp = int(time.time())
         # Make file with known timestamp
-        with open("test.txt","w") as fp:
+        with open("test.txt","wt") as fp:
             fp.write("test")
         os.utime("test.txt",(timestamp,timestamp))
         self.assertEqual(FilesystemObject("test.txt").timestamp,
@@ -81,7 +81,7 @@ class TestFilesystemObject(unittest.TestCase):
 
     def test_size(self):
         # Make file
-        with open("test.txt","w") as fp:
+        with open("test.txt","wt") as fp:
             fp.write("test")
         self.assertEqual(FilesystemObject("test.txt").size,4)
 
@@ -89,7 +89,7 @@ class TestFilesystemObject(unittest.TestCase):
         # Get UID for current user
         current_uid = os.getuid()
         # Make file
-        with open("test.txt","w") as fp:
+        with open("test.txt","wt") as fp:
             fp.write("test")
         self.assertEqual(FilesystemObject("test.txt").uid,
                          current_uid)
@@ -98,7 +98,7 @@ class TestFilesystemObject(unittest.TestCase):
         # Get username for current user
         current_username = getpass.getuser()
         # Make file
-        with open("test.txt","w") as fp:
+        with open("test.txt","wt") as fp:
             fp.write("test")
         self.assertEqual(FilesystemObject("test.txt").username,
                          current_username)
@@ -107,7 +107,7 @@ class TestFilesystemObject(unittest.TestCase):
         # Get GID for current user
         current_gid = os.getgid()
         # Make file
-        with open("test.txt","w") as fp:
+        with open("test.txt","wt") as fp:
             fp.write("test")
         self.assertEqual(FilesystemObject("test.txt").gid,
                          current_gid)
@@ -116,7 +116,7 @@ class TestFilesystemObject(unittest.TestCase):
         # Get group name for current user
         current_groupname = grp.getgrgid(os.getgid()).gr_name
         # Make file
-        with open("test.txt","w") as fp:
+        with open("test.txt","wt") as fp:
             fp.write("test")
         self.assertEqual(FilesystemObject("test.txt").groupname,
                          current_groupname)
@@ -125,7 +125,7 @@ class TestFilesystemObject(unittest.TestCase):
         # Doesn't exist
         self.assertFalse(FilesystemObject("test").islink)
         # File that exists
-        with open("test.txt","w") as fp:
+        with open("test.txt","wt") as fp:
             fp.write("test")
         self.assertFalse(FilesystemObject("test.txt").islink)
         # Directory
@@ -142,7 +142,7 @@ class TestFilesystemObject(unittest.TestCase):
         # Doesn't exist
         self.assertFalse(FilesystemObject("test").isfile)
         # File that exists
-        with open("test.txt","w") as fp:
+        with open("test.txt","wt") as fp:
             fp.write("test")
         self.assertTrue(FilesystemObject("test.txt").isfile)
         # Directory
@@ -159,7 +159,7 @@ class TestFilesystemObject(unittest.TestCase):
         # Doesn't exist
         self.assertFalse(FilesystemObject("test").isdir)
         # File that exists
-        with open("test.txt","w") as fp:
+        with open("test.txt","wt") as fp:
             fp.write("test")
         self.assertFalse(FilesystemObject("test.txt").isdir)
         # Directory
@@ -174,15 +174,15 @@ class TestFilesystemObject(unittest.TestCase):
 
     def test_iscompressed(self):
         # Uncompressed file
-        with open("test.txt","w") as fp:
+        with open("test.txt","wt") as fp:
             fp.write("uncompressed")
         self.assertFalse(FilesystemObject("test.txt").iscompressed)
         # Gzipped file
-        with gzip.open("test.txt.gz","w") as fp:
+        with gzip.open("test.txt.gz","wt") as fp:
             fp.write("gzipped")
         self.assertTrue(FilesystemObject("test.txt.gz").iscompressed)
         # Bzipped2 file
-        with bz2.BZ2File("test.txt.bz2","w") as fp:
+        with bz2.open("test.txt.bz2","wt") as fp:
             fp.write("bzipped2")
         self.assertTrue(FilesystemObject("test.txt.bz2").iscompressed)
 
@@ -191,7 +191,7 @@ class TestFilesystemObject(unittest.TestCase):
         self.assertEqual(FilesystemObject("test").type,
                          FilesystemObjectType.MISSING)
         # File that exists
-        with open("test.txt","w") as fp:
+        with open("test.txt","wt") as fp:
             fp.write("test")
         self.assertEqual(FilesystemObject("test.txt").type,
                          FilesystemObjectType.FILE)
@@ -210,7 +210,7 @@ class TestFilesystemObject(unittest.TestCase):
 
     def test_raw_symlink_target(self):
         # Make file and symlink
-        with open("test.txt","w") as fp:
+        with open("test.txt","wt") as fp:
             fp.write("test")
         os.symlink("test.txt","test.lnk")
         self.assertEqual(
@@ -224,10 +224,10 @@ class TestFilesystemObject(unittest.TestCase):
 
     def test_ishidden(self):
         # Make test filesystem objects
-        with open("test.txt","w") as fp:
+        with open("test.txt","wt") as fp:
             fp.write("test")
         self.assertFalse(FilesystemObject("test.txt").ishidden)
-        with open(".hidden.txt","w") as fp:
+        with open(".hidden.txt","wt") as fp:
             fp.write("test")
         self.assertTrue(FilesystemObject(".hidden.txt").ishidden)
         # Directory
@@ -236,22 +236,22 @@ class TestFilesystemObject(unittest.TestCase):
         os.mkdir(".hidden.dir")
         self.assertTrue(FilesystemObject(".hidden.dir").ishidden)
         # Files in subdirs
-        with open("test.dir/test.txt","w") as fp:
+        with open("test.dir/test.txt","wt") as fp:
             fp.write("test")
         self.assertFalse(FilesystemObject("test.dir/test.txt").ishidden)
-        with open("test.dir/.hidden.txt","w") as fp:
+        with open("test.dir/.hidden.txt","wt") as fp:
             fp.write("test")
         self.assertTrue(FilesystemObject("test.dir/.hidden.txt").ishidden)
-        with open(".hidden.dir/test.txt","w") as fp:
+        with open(".hidden.dir/test.txt","wt") as fp:
             fp.write("test")
         self.assertTrue(FilesystemObject(".hidden.dir/test.txt").ishidden)
-        with open(".hidden.dir/.hidden.txt","w") as fp:
+        with open(".hidden.dir/.hidden.txt","wt") as fp:
             fp.write("test")
         self.assertTrue(FilesystemObject(".hidden.dir/.hidden.txt").ishidden)
 
     def test_isaccessible(self):
         # Make test filesystem objects
-        with open("test.txt","w") as fp:
+        with open("test.txt","wt") as fp:
             fp.write("test")
         self.assertTrue(FilesystemObject("test.txt").isaccessible)
         # Directory
@@ -272,14 +272,14 @@ class TestFilesystemObject(unittest.TestCase):
 
     def test_md5sum(self):
         # Make test filesystem objects
-        with open("test.txt","w") as fp:
+        with open("test.txt","wt") as fp:
             fp.write("test")
         self.assertEqual(FilesystemObject("test.txt").md5sum,
                          "098f6bcd4621d373cade4e832627b4f6")
 
     def test_linux_permissions(self):
         # Make test filesystem object
-        with open("test.txt","w") as fp:
+        with open("test.txt","wt") as fp:
             fp.write("test")
         # Set permissions and test outputs
         os.chmod("test.txt",0o444)
@@ -297,15 +297,15 @@ class TestFilesystemObject(unittest.TestCase):
 
     def test_extension(self):
         # Make test filesystem objects
-        with open("test.txt","w") as fp:
+        with open("test.txt","wt") as fp:
             fp.write("test")
-        with open("test.txt.gz","w") as fp:
+        with open("test.txt.gz","wt") as fp:
             fp.write("test")
-        with open("test.txt.filtered.gz.1","w") as fp:
+        with open("test.txt.filtered.gz.1","wt") as fp:
             fp.write("test")
-        with open("test.gz","w") as fp:
+        with open("test.gz","wt") as fp:
             fp.write("test")
-        with open("test","w") as fp:
+        with open("test","wt") as fp:
             fp.write("test")
         # Check extensions
         self.assertEqual(FilesystemObject("test.txt").extension,
@@ -319,15 +319,15 @@ class TestFilesystemObject(unittest.TestCase):
 
     def test_type_extension(self):
         # Make test filesystem objects
-        with open("test.txt","w") as fp:
+        with open("test.txt","wt") as fp:
             fp.write("test")
-        with open("test.txt.gz","w") as fp:
+        with open("test.txt.gz","wt") as fp:
             fp.write("test")
-        with open("test.txt.filtered.gz.1","w") as fp:
+        with open("test.txt.filtered.gz.1","wt") as fp:
             fp.write("test")
-        with open("test.gz","w") as fp:
+        with open("test.gz","wt") as fp:
             fp.write("test")
-        with open("test","w") as fp:
+        with open("test","wt") as fp:
             fp.write("test")
         # Check type extensions
         self.assertEqual(FilesystemObject("test.txt").type_extension,
@@ -368,7 +368,7 @@ class TestFilesystemObjectIndex(unittest.TestCase):
         for d in dirs:
             os.mkdir(d)
         for f in files:
-            with open(f,"w") as fp:
+            with open(f,"wt") as fp:
                 fp.write("test\n")
         for s in symlinks:
             os.symlink(symlinks[s],s)
@@ -426,7 +426,7 @@ class TestCompareFunction(unittest.TestCase):
         for d in dirs:
             os.mkdir(os.path.join(dirn,d))
         for f in files:
-            with open(os.path.join(dirn,f),"w") as fp:
+            with open(os.path.join(dirn,f),"wt") as fp:
                 fp.write("blah\n")
         for s in symlinks:
             os.symlink(symlinks[s],os.path.join(dirn,s))
@@ -481,11 +481,11 @@ class TestCompareFunction(unittest.TestCase):
         # Remove a file (missing)
         os.remove("test2/test.txt")
         # Add a new file (extra)
-        with open("test2/test2.dir/new.txt","w") as fp:
+        with open("test2/test2.dir/new.txt","wt") as fp:
             fp.write("blah")
         # Change content (changed_size/changed_md5/changed_time)
         time.sleep(.01)
-        with open("test2/test2.dir/test.txt","w") as fp:
+        with open("test2/test2.dir/test.txt","wt") as fp:
             fp.write("blah")
         # Build indexes
         indx1 = FilesystemObjectIndex("test1")
@@ -518,14 +518,14 @@ class TestCompareFunction(unittest.TestCase):
         os.symlink(".","test2/test2.dir/test.txt")
         # Change a directory to a file
         shutil.rmtree("test2/test1.dir")
-        with open("test2/test1.dir","w") as fp:
+        with open("test2/test1.dir","wt") as fp:
             fp.write("blah")
         # Change a directory to a link
         shutil.rmtree("test2/test3.dir")
         os.symlink(".","test2/test3.dir")
         # Change a link to a file
         os.remove("test2/test1.lnk")
-        with open("test2/test1.lnk","w") as fp:
+        with open("test2/test1.lnk","wt") as fp:
             fp.write("blah")
         # Change a link to a directory
         os.remove("test2/test2.lnk")
@@ -632,7 +632,7 @@ class TestCheckAccessibilityFunction(unittest.TestCase):
         for d in dirs:
             os.mkdir(os.path.join(dirn,d))
         for f in files:
-            with open(os.path.join(dirn,f),"w") as fp:
+            with open(os.path.join(dirn,f),"wt") as fp:
                 fp.write("blah\n")
         for s in symlinks:
             os.symlink(symlinks[s],os.path.join(dirn,s))
@@ -693,10 +693,10 @@ class TestFindFunction(unittest.TestCase):
         for d in dirs:
             os.mkdir(os.path.join(dirn,d))
         for f in files:
-            with open(os.path.join(dirn,f),"w") as fp:
+            with open(os.path.join(dirn,f),"wt") as fp:
                 fp.write("blah\n")
-        with open(os.path.join(dirn,"big_file"),"w") as fp:
-            for i in xrange(1,1000):
+        with open(os.path.join(dirn,"big_file"),"wt") as fp:
+            for i in range(1,1000):
                 fp.write("BLAHBLAHBLAH\n")
         for s in symlinks:
             os.symlink(symlinks[s],os.path.join(dirn,s))

--- a/stoker/test/test_index.py
+++ b/stoker/test/test_index.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python3
 #
 # Unit tests for the stoker index module
 import unittest


### PR DESCRIPTION
PR to update `stoker` to work under Python 3 (specifically 3.6, 3.7 and 3.8). Support for Python 2 is dropped as part of this update.